### PR TITLE
Fix `ghosler update` Deleting the New Config File.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler-cli",
-  "version": "1.0.86",
+  "version": "1.0.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler-cli",
-      "version": "1.0.86",
+      "version": "1.0.88",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghosler-cli",
-  "version": "1.0.86",
+  "version": "1.0.88",
   "description": "A basic, simple CLI for installing, managing Ghosler instances.",
   "main": "app.js",
   "type": "module",

--- a/utils/commands/update.js
+++ b/utils/commands/update.js
@@ -14,8 +14,18 @@ export default class Update extends BaseCommand {
     static #toIgnore = [
         '.logs', 'files', '.backups',
         'README.md', 'LICENSE.md', '.gitignore',
+
+        // pre docker
+        'config.debug.json',
+        'custom-template.ejs',
+        'config.production.json',
+
+        // post docker
+        'configuration/config.debug.json',
+        'configuration/config.local.json',
+        'configuration/custom-template.ejs',
+        'configuration/config.production.json',
         'Dockerfile', '.dockerignore', 'docker-install.sh',
-        'config.debug.json', 'custom-template.ejs', 'config.production.json',
     ];
 
     static yargsCommand() {

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -25,7 +25,7 @@ export default class Utils {
      *
      * @type {string}
      */
-    static cliPackageVersion = '1.0.86';
+    static cliPackageVersion = '1.0.88';
     // Urls to download Ghosler from its GitHub source.
     static ghoslerReleaseUrl = 'https://api.github.com/repos/itznotabug/ghosler/releases/latest';
     static ghoslerReleaseDownloadUrl = 'https://github.com/itznotabug/ghosler/archive/refs/tags/{version}.zip';


### PR DESCRIPTION
This PR fixes an issue introduced with the release of `ghosler >= 0.94` while performing an update like `ghosler update`. Since the new configuration file is now located inside `configuration` directory and wasn't excluded, it is deleted on an update.